### PR TITLE
replace bare variables for full variable syntax

### DIFF
--- a/tasks/package-apt.yml
+++ b/tasks/package-apt.yml
@@ -8,6 +8,6 @@
     cache_valid_time: "{{ package_cache_valid_time }}"
   when: (item.apt_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
-    - package_list
-    - package_list_host
-    - package_list_group
+    - "{{ package_list }}"
+    - "{{ package_list_host }}"
+    - "{{ package_list_group }}"

--- a/tasks/package-brew.yml
+++ b/tasks/package-brew.yml
@@ -7,7 +7,6 @@
     state: "{{ item.state | default(package_state) }}"
   when: (item.brew_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
-    - package_list
-    - package_list_host
-    - package_list_group
-
+    - "{{ package_list }}"
+    - "{{ package_list_host }}"
+    - "{{ package_list_group }}"

--- a/tasks/package-pacman.yml
+++ b/tasks/package-pacman.yml
@@ -6,6 +6,6 @@
     state: "{{ item.state | default(package_state) }}"
   when: (item.pacman_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
-    - package_list
-    - package_list_host
-    - package_list_group
+    - "{{ package_list }}"
+    - "{{ package_list_host }}"
+    - "{{ package_list_group }}"

--- a/tasks/package-portage.yml
+++ b/tasks/package-portage.yml
@@ -7,6 +7,6 @@
     sync: "{{ package_update_cache }}"
   when: (item.portage_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
-    - package_list
-    - package_list_host
-    - package_list_group
+    - "{{ package_list }}"
+    - "{{ package_list_host }}"
+    - "{{ package_list_group }}"

--- a/tasks/package-yum.yml
+++ b/tasks/package-yum.yml
@@ -7,7 +7,6 @@
     update_cache: "{{ package_update_cache }}"
   when: (item.yum_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
-    - package_list
-    - package_list_host
-    - package_list_group
-
+    - "{{ package_list }}"
+    - "{{ package_list_host }}"
+    - "{{ package_list_group }}"

--- a/tasks/package-zypper.yml
+++ b/tasks/package-zypper.yml
@@ -6,6 +6,6 @@
     state: "{{ item.state | default(package_state) }}"
   when: (item.zypper_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
-    - package_list
-    - package_list_host
-    - package_list_group
+    - "{{ package_list }}"
+    - "{{ package_list_host }}"
+    - "{{ package_list_group }}"


### PR DESCRIPTION
with ansible 2.0 the following deprecation warning is emitted:
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment
value uses the full variable syntax ('{{package_list}}').
This feature will be removed in a future
release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

This is fixed by replacing the use of package_list\*  with "{{ package_list\* }}"
