### PR TITLE
Add apt_install_recommends option for package item

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ in the list can have following attributes:
 | `state` | Package state | no |
 | `apt` | Package name for apt | no |
 | `apt_ignore` | Ignore package for apt | no |
+| `apt_install_recommends` | Whether to install recommended dependencies apt    | no |
 | `yum` | Package name for yum | no |
 | `yum_ignore` | Ignore package for yum | no |
 | `dnf` | Package name for dnf | no |

--- a/tasks/package-apt.yml
+++ b/tasks/package-apt.yml
@@ -6,6 +6,7 @@
     state: "{{ item.state | default(package_state) }}"
     update_cache: "{{ package_update_cache }}"
     cache_valid_time: "{{ package_cache_valid_time }}"
+    install_recommends: "{{ item.apt_install_recommends | default(omit) }}"
   when: (item.apt_ignore|default('no'))|string in 'False,false,No,no'
   with_flattened:
     - "{{ package_list }}"


### PR DESCRIPTION
Hi,

That would be a nice feature to allow apt users to not trigger installation of recommended dependencies. See http://docs.ansible.com/ansible/apt_module.html

I don't see any minimal version in ansible documentation. So that should be safe for backward compatibility.

What do you think of this ?

<!--
cc @toopy
-->
