### PR TITLE
Compatibility with ansible 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
   # Run the role/playbook with ansible-playbook.
-  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user=root
+  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --become
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user=root
+    ansible-playbook tests/test.yml -i tests/inventory --connection=local --become
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
   # Run the role/playbook with ansible-playbook.
-  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --sudo
+  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook tests/test.yml -i tests/inventory --connection=local --sudo
+    ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 
 install:
   # Install Ansible.
-  - pip install ansible
+  - pip install ansible==2.4.6.0
 
   # Check ansible version
   - ansible --version
@@ -29,11 +29,11 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
   # Run the role/playbook with ansible-playbook.
-  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user
+  - ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user=root
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user
+    ansible-playbook tests/test.yml -i tests/inventory --connection=local --become-user=root
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
-- include: package-apt.yml
+- import_tasks: package-apt.yml
   when: ansible_pkg_mgr == 'apt'
 
-- include: package-yum.yml
+- import_tasks: package-yum.yml
   when: ansible_pkg_mgr == 'yum'
 
-- include: package-dnf.yml
+- import_tasks: package-dnf.yml
   when: ansible_pkg_mgr == 'dnf'
 
-- include: package-brew.yml
+- import_tasks: package-brew.yml
   when: ansible_os_family == 'Darwin'
 
-- include: package-zypper.yml
+- import_tasks: package-zypper.yml
   when: ansible_pkg_mgr == 'zypper'
 
-- include: package-pacman.yml
+- import_tasks: package-pacman.yml
   when: ansible_pkg_mgr == 'pacman'
 
-- include: package-portage.yml
+- import_tasks: package-portage.yml
   when: ansible_pkg_mgr == 'portage'


### PR DESCRIPTION
replaced deprecated "include" with "import_tasks"
use "--become" instead of "--sudo" for .travis test

Require ansible 2.4 which is reasonable, considering that it is 2 years old already.

I really like this role, but it currently emits the deprecation warning for the "include" module.
Some of my roles, that include this as a dependency - I would like to use with an even more recent ansible version, so this would be a first step to make it compatible.

Thanks