### PR TITLE
eliminate duplicate packages on merge

### DIFF
--- a/tasks/package-apt.yml
+++ b/tasks/package-apt.yml
@@ -8,7 +8,4 @@
     cache_valid_time: "{{ package_cache_valid_time }}"
     install_recommends: "{{ item.apt_install_recommends | default(omit) }}"
   when: (item.apt_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-apt.yml
+++ b/tasks/package-apt.yml
@@ -8,4 +8,4 @@
     cache_valid_time: "{{ package_cache_valid_time }}"
     install_recommends: "{{ item.apt_install_recommends | default(omit) }}"
   when: (item.apt_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/tasks/package-brew.yml
+++ b/tasks/package-brew.yml
@@ -6,7 +6,4 @@
     name: "{{ item.brew | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.brew_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-brew.yml
+++ b/tasks/package-brew.yml
@@ -6,4 +6,4 @@
     name: "{{ item.brew | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.brew_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/tasks/package-dnf.yml
+++ b/tasks/package-dnf.yml
@@ -5,7 +5,4 @@
     name: "{{ item.dnf | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.dnf_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-dnf.yml
+++ b/tasks/package-dnf.yml
@@ -5,4 +5,4 @@
     name: "{{ item.dnf | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.dnf_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/tasks/package-pacman.yml
+++ b/tasks/package-pacman.yml
@@ -5,4 +5,4 @@
     name: "{{ item.pacman | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.pacman_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/tasks/package-pacman.yml
+++ b/tasks/package-pacman.yml
@@ -5,7 +5,4 @@
     name: "{{ item.pacman | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.pacman_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-portage.yml
+++ b/tasks/package-portage.yml
@@ -6,4 +6,4 @@
     state: "{{ item.state | default(package_state) }}"
     sync: "{{ package_update_cache }}"
   when: (item.portage_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/tasks/package-portage.yml
+++ b/tasks/package-portage.yml
@@ -6,7 +6,4 @@
     state: "{{ item.state | default(package_state) }}"
     sync: "{{ package_update_cache }}"
   when: (item.portage_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-yum.yml
+++ b/tasks/package-yum.yml
@@ -6,7 +6,4 @@
     state: "{{ item.state | default(package_state) }}"
     update_cache: "{{ package_update_cache }}"
   when: (item.yum_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-yum.yml
+++ b/tasks/package-yum.yml
@@ -6,4 +6,4 @@
     state: "{{ item.state | default(package_state) }}"
     update_cache: "{{ package_update_cache }}"
   when: (item.yum_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/tasks/package-zypper.yml
+++ b/tasks/package-zypper.yml
@@ -5,7 +5,4 @@
     name: "{{ item.zypper | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.zypper_ignore|default('no'))|string in 'False,false,No,no'
-  with_flattened:
-    - "{{ package_list }}"
-    - "{{ package_list_host }}"
-    - "{{ package_list_group }}"
+  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"

--- a/tasks/package-zypper.yml
+++ b/tasks/package-zypper.yml
@@ -5,4 +5,4 @@
     name: "{{ item.zypper | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
   when: (item.zypper_ignore|default('no'))|string in 'False,false,No,no'
-  with_items: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"
+  with_items: "{{ packages }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+# List of unique packages
+packages: "{{ (package_list + package_list_group + package_list_host ) | list | unique }}"


### PR DESCRIPTION
fix for handling duplicated package (#9) suggested by Marek Krasnowski. Helps eliminate duplicates to speed up package installation.