### PR TITLE
include update cache capability on brew, dnf, pacman, zypper

### DIFF
--- a/tasks/package-brew.yml
+++ b/tasks/package-brew.yml
@@ -5,5 +5,6 @@
   homebrew:
     name: "{{ item.brew | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
+    update_homebrew: "{{ package_update_cache }}"
   when: (item.brew_ignore|default('no'))|string in 'False,false,No,no'
   with_items: "{{ packages }}"

--- a/tasks/package-dnf.yml
+++ b/tasks/package-dnf.yml
@@ -4,5 +4,6 @@
   dnf:
     name: "{{ item.dnf | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
+    update_cache: "{{ package_update_cache }}"
   when: (item.dnf_ignore|default('no'))|string in 'False,false,No,no'
   with_items: "{{ packages }}"

--- a/tasks/package-pacman.yml
+++ b/tasks/package-pacman.yml
@@ -4,5 +4,6 @@
   pacman:
     name: "{{ item.pacman | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
+    update_cache: "{{ package_update_cache }}"
   when: (item.pacman_ignore|default('no'))|string in 'False,false,No,no'
   with_items: "{{ packages }}"

--- a/tasks/package-zypper.yml
+++ b/tasks/package-zypper.yml
@@ -4,5 +4,6 @@
   zypper:
     name: "{{ item.zypper | default(item.name) }}"
     state: "{{ item.state | default(package_state) }}"
+    update_cache: "{{ package_update_cache }}"
   when: (item.zypper_ignore|default('no'))|string in 'False,false,No,no'
   with_items: "{{ packages }}"


### PR DESCRIPTION
Would be nice to have the update cache capability on the following package managers to align with apt and yum:
- brew
- dnf
- pacman
- zypper