### PR TITLE
Update: Improved runtime by using first_found and added additional package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ in the list can have following attributes:
 | `apt` | Package name for apt | no |
 | `apt_ignore` | Ignore package for apt | no |
 | `apt_install_recommends` | Whether to install recommended dependencies apt    | no |
+| `apk` | Package name for apk | no |
+| `apk_ignore` | Ignore package for apk | no |
 | `yum` | Package name for yum | no |
 | `yum_ignore` | Ignore package for yum | no |
 | `dnf` | Package name for dnf | no |
@@ -61,6 +63,8 @@ in the list can have following attributes:
 | `pacman_ignore` | Ignore package for pacman | no |
 | `portage` | Package name for portage | no |
 | `portage_ignore` | Ignore package for portage | no |
+| `opkg` | Package name for opkg | no |
+| `opkg_ignore` | Ignore package for opkg | no |
 
 By default `package_state` and `item.name` are used when managing the packages.
 If however `item.state` is defined or a more specific package name (eg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,26 @@
 ---
 
-- import_tasks: package-apt.yml
-  when: ansible_pkg_mgr == 'apt'
+- import_tasks: "{{ item }}"
+  with_first_found:
+    - "package-{{ ansible_pkg_mgr }}"
 
-- import_tasks: package-yum.yml
-  when: ansible_pkg_mgr == 'yum'
-
-- import_tasks: package-dnf.yml
-  when: ansible_pkg_mgr == 'dnf'
-
-- import_tasks: package-brew.yml
-  when: ansible_os_family == 'Darwin'
-
-- import_tasks: package-zypper.yml
-  when: ansible_pkg_mgr == 'zypper'
-
-- import_tasks: package-pacman.yml
-  when: ansible_pkg_mgr == 'pacman'
-
-- import_tasks: package-portage.yml
-  when: ansible_pkg_mgr == 'portage'
+#- import_tasks: package-apt.yml
+#  when: ansible_pkg_mgr == 'apt'
+#
+#- import_tasks: package-yum.yml
+#  when: ansible_pkg_mgr == 'yum'
+#
+#- import_tasks: package-dnf.yml
+#  when: ansible_pkg_mgr == 'dnf'
+#
+#- import_tasks: package-brew.yml
+#  when: ansible_os_family == 'Darwin'
+#
+#- import_tasks: package-zypper.yml
+#  when: ansible_pkg_mgr == 'zypper'
+#
+#- import_tasks: package-pacman.yml
+#  when: ansible_pkg_mgr == 'pacman'
+#
+#- import_tasks: package-portage.yml
+#  when: ansible_pkg_mgr == 'portage'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - import_tasks: "{{ item }}"
   with_first_found:
-    - "package-{{ ansible_pkg_mgr }}"
+    - "package-{{ ansible_pkg_mgr }}.yml"
 
 #- import_tasks: package-apt.yml
 #  when: ansible_pkg_mgr == 'apt'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- import_tasks: "{{ item }}"
+- include_tasks: "{{ item }}"
   with_first_found:
     - "package-{{ ansible_pkg_mgr }}.yml"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
 
-- include_tasks: "{{ item }}"
+- include_tasks: "{{ package_manager }}"
   with_first_found:
     - "package-{{ ansible_pkg_mgr }}.yml"
+  loop_control:
+    loop_var: package_manager
 
 #- import_tasks: package-apt.yml
 #  when: ansible_pkg_mgr == 'apt'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,24 +5,3 @@
     - "package-{{ ansible_pkg_mgr }}.yml"
   loop_control:
     loop_var: package_manager
-
-#- import_tasks: package-apt.yml
-#  when: ansible_pkg_mgr == 'apt'
-#
-#- import_tasks: package-yum.yml
-#  when: ansible_pkg_mgr == 'yum'
-#
-#- import_tasks: package-dnf.yml
-#  when: ansible_pkg_mgr == 'dnf'
-#
-#- import_tasks: package-brew.yml
-#  when: ansible_os_family == 'Darwin'
-#
-#- import_tasks: package-zypper.yml
-#  when: ansible_pkg_mgr == 'zypper'
-#
-#- import_tasks: package-pacman.yml
-#  when: ansible_pkg_mgr == 'pacman'
-#
-#- import_tasks: package-portage.yml
-#  when: ansible_pkg_mgr == 'portage'

--- a/tasks/package-apk.yml
+++ b/tasks/package-apk.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Apk
+  apk:
+    name: "{{ item.apk | default(item.name) }}"
+    state: "{{ item.state | default(package_state) }}"
+    update_cache: "{{ package_update_cache }}"
+  when: (item.apk_ignore|default('no'))|string in 'False,false,No,no'
+  with_items: "{{ packages }}"

--- a/tasks/package-opkg.yml
+++ b/tasks/package-opkg.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Opkg
+  opkg:
+    name: "{{ item.opkg | default(item.name) }}"
+    state: "{{ item.state | default(package_state) }}"
+    update_cache: "{{ package_update_cache }}"
+  when: (item.opk_ignore|default('no'))|string in 'False,false,No,no'
+  with_items: "{{ packages }}"


### PR DESCRIPTION
I updated the main file to use include_tasks with a first_found lookup based on the package_manager fact. This reduces runtime greatly so it does not have to iterate through all the package managers and only uses the task that is relevant to the system it runs on.

Added support for apk and opkg package managers.